### PR TITLE
Hotfix/donghoon/limit input length

### DIFF
--- a/summary_demo.py
+++ b/summary_demo.py
@@ -44,7 +44,7 @@ def process(context: str, doc_type: DocumentType) -> str:
         api_url = query_param['api'][0]
         try:
             headers = {'Content-Type': 'application/json; charset=utf-8'}
-            response = requests.post(url=api_url, headers=headers, json={"context": context, "docType": doc_type})
+            response = requests.post(url=api_url, headers=headers, json={"context": preprocessor.run(context), "docType": doc_type})
 
             output = response.json()
 

--- a/summary_demo.py
+++ b/summary_demo.py
@@ -36,12 +36,15 @@ class TextGenerationOutput(BaseModel):
 
 def process(context: str, doc_type: DocumentType) -> str:
     query_param = st.experimental_get_query_params()
+
+    if len(context) > 3000:
+        context = context[:3000]
     
     if 'api' in query_param:
         api_url = query_param['api'][0]
         try:
             headers = {'Content-Type': 'application/json; charset=utf-8'}
-            response = requests.post(url=api_url, headers=headers, json={"context": preprocessor.run(context), "docType": doc_type})
+            response = requests.post(url=api_url, headers=headers, json={"context": context, "docType": doc_type})
 
             output = response.json()
 


### PR DESCRIPTION
- Input context에 3000자로 길이제한 설정.
- 3000자가 넘어가면 자름.

< How to work >
1. docker build "Docker image name" -t .
2. docker run -it -p 8051:8051 "Docker image name"
3. http://localhost:8051 접속